### PR TITLE
Дополнительные параметры для yt-dlp, чтобы скачанные видео воспроизводились на iOS/MacOS

### DIFF
--- a/RaterBot/DownloadHelper.cs
+++ b/RaterBot/DownloadHelper.cs
@@ -82,7 +82,7 @@ internal static class DownloadHelper
             StartInfo = new ProcessStartInfo
             {
                 FileName = "yt-dlp",
-                Arguments = $"{url} -o {file}",
+                Arguments = $"{url} -o {file} -f \"bestvideo[height<=1080][vcodec^=avc][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best\"",
                 CreateNoWindow = true,
             },
         };


### PR DESCRIPTION
Похоже, webm не особо хочет работать на маке (как минимум, в видеоплеере телеги). Гуглёж привёл на Reddit, к параметрам в коммите
https://www.reddit.com/r/youtubedl/comments/155whry/comment/jswxtsh/

С этими параметрами yt-dlp выкачает `mp4` вместо `webm`
Разница в размере [одного и того же видео](https://www.youtube.com/watch?v=h_b5WUfaxh4):
![image](https://github.com/user-attachments/assets/048d034b-8689-45bd-9c4c-6ce474cd6d9c)
Слева: `yt-dlp.exe https://www.youtube.com/watch?v=h_b5WUfaxh4`, справа: `yt-dlp.exe https://www.youtube.com/watch?v=h_b5WUfaxh4 -f "bestvideo[height<=1080][vcodec^=avc][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"`
(не знаю, почему так - вроде, webm должен быть поменьше; проверял из-под Windows 11)

Бота в тесте после этого изменения не разворачивал, поэтому думаю, что стоит перепроверить