### PR TITLE
fix: preserve ё и й in zalgo normalization

### DIFF
--- a/RaterBot/TelegramHelper.cs
+++ b/RaterBot/TelegramHelper.cs
@@ -75,8 +75,7 @@ namespace RaterBot
         private static string RemoveZalgo(string input)
         {
             var normalized = input.Normalize(NormalizationForm.FormD);
-            var cleaned = new string([.. normalized.Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)]);
-            return cleaned.Normalize(NormalizationForm.FormC);
+            return new string([.. normalized.Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)]);
         }
 
         public static string UserEscaped(User user)


### PR DESCRIPTION
Без второй нормализации й и ё сохраняются