### PR TITLE
fix: use two normalizations to combine characters

### DIFF
--- a/RaterBot/TelegramHelper.cs
+++ b/RaterBot/TelegramHelper.cs
@@ -74,7 +74,7 @@ namespace RaterBot
 
         private static string RemoveZalgo(string input)
         {
-            var normalized = input.Normalize(NormalizationForm.FormD);
+            var normalized = input.Normalize(NormalizationForm.FormD).Normalize(NormalizationForm.FormC);
             return new string([.. normalized.Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)]);
         }
 


### PR DESCRIPTION
Accoring to https://en.wikipedia.org/wiki/Unicode_equivalence#Normal_forms

> For example, the distinct Unicode strings "U+212B" (the angstrom sign "Å") and "U+00C5" (the Swedish letter "Å") are both expanded by NFD (or NFKD) into the sequence "U+0041 U+030A" (Latin letter "A" and combining [ring above](https://en.wikipedia.org/wiki/Ring_above) "°") which is then reduced by NFC (or NFKC) to "U+00C5" (the Swedish letter "Å").

https://dotnetfiddle.net/iqo2QW