### PR TITLE
fix: 20240629_AddMediaHash migration

### DIFF
--- a/RaterBot.Database/Migrations/20240629_AddMediaHash.cs
+++ b/RaterBot.Database/Migrations/20240629_AddMediaHash.cs
@@ -2,7 +2,7 @@ using FluentMigrator;
 
 namespace RaterBot.Database.Migrations;
 
-[Migration(20240629)]
+[Migration(20240629000000)]
 public class AddMediaHash : Migration
 {
     public override void Up()


### PR DESCRIPTION
FluentMigrator orders by the numeric value, so 20240629 runs before 20211006235400, causing ALTER TABLE "Post" to run before Post is created.